### PR TITLE
set force to true when writing delta entity states

### DIFF
--- a/codemp/client/cl_demos.cpp
+++ b/codemp/client/cl_demos.cpp
@@ -215,7 +215,7 @@ static void demoFramePack( msg_t *msg, const demoFrame_t *newFrame, const demoFr
 				oldEntity = &demoNullEntityState;
 			}
 		}
-		MSG_WriteDeltaEntity( msg, (entityState_t *)oldEntity, (entityState_t *)newEntity, qfalse );
+		MSG_WriteDeltaEntity( msg, (entityState_t *)oldEntity, (entityState_t *)newEntity, qtrue );
 	}
 	MSG_WriteBits( msg, (MAX_GENTITIES-1), GENTITYNUM_BITS );
 	/* Add the area mask */


### PR DESCRIPTION
fixes sometimes entities getting corrupted.
alternate fix could be to go further than 1 previous snap backwards when
looking for a prev entityState to delta from, i guess that is what normal
demos do