### PR TITLE
Added new demo tokens: server name and strftime timestamps

### DIFF
--- a/codemp/client/cl_demos_auto.cpp
+++ b/codemp/client/cl_demos_auto.cpp
@@ -21,11 +21,13 @@ char *demoAutoFormat(const char* name) {
 	qtime_t ct;
 	struct tm tt;
 
-	char playerName[MAX_QPATH], serverName[MAX_QPATH];
-	char *mapName = COM_SkipPath(Info_ValueForKey((cl.gameState.stringData + cl.gameState.stringOffsets[CS_SERVERINFO]), "mapname"));
-	Q_strncpyz(playerName, Info_ValueForKey((cl.gameState.stringData + cl.gameState.stringOffsets[CS_PLAYERS+cl.snap.ps.clientNum]), "n"), sizeof(playerName));
+	char playerName[MAX_QPATH], serverName[MAX_QPATH], mapName[MAX_QPATH];
+	Q_strncpyz(playerName, COM_SkipPath(Info_ValueForKey((cl.gameState.stringData + cl.gameState.stringOffsets[CS_PLAYERS+cl.snap.ps.clientNum]), "n")), sizeof(playerName));
+	Q_strncpyz(serverName, COM_SkipPath(Info_ValueForKey((cl.gameState.stringData + cl.gameState.stringOffsets[CS_SERVERINFO]), "sv_hostname")), sizeof(serverName));
+	Q_strncpyz(mapName, COM_SkipPath(Info_ValueForKey((cl.gameState.stringData + cl.gameState.stringOffsets[CS_SERVERINFO]), "mapname")), sizeof(mapName));
 	Q_StripColor(playerName, cls.uag.newColors);
-	Q_StripColor(serverName, COM_SkipPath(Info_ValueForKey((cl.gameState.stringData + cl.gameState.stringOffsets[CS_SERVERINFO]), "sv_hostname")));
+	Q_StripColor(serverName, cls.uag.newColors);
+	Q_StripColor(mapName, cls.uag.newColors);
 	Com_RealTime(&ct);
 	
 	format = cl_autoDemoFormat->string;
@@ -51,8 +53,8 @@ char *demoAutoFormat(const char* name) {
 				tt.tm_sec = ct.tm_sec; tt.tm_min = ct.tm_min; tt.tm_hour = ct.tm_hour;
 				tt.tm_mday = ct.tm_mday; tt.tm_mon = ct.tm_mon; tt.tm_year = ct.tm_year;
 				tt.tm_wday = ct.tm_wday; tt.tm_yday = ct.tm_yday; tt.tm_isdst = ct.tm_isdst;
-				strftime( outBuf + outIndex, outLeft, va( "%%%c", ch ), &tt );
-				outIndex += strlen( outBuf + outIndex );
+				strftime(outBuf + outIndex, outLeft, va("%%%c", ch), &tt);
+				outIndex += strlen(outBuf + outIndex);
 				break;
 			case 'D':		//date
 				Com_sprintf( outBuf + outIndex, outLeft, "%d-%02d-%02d-%02d%02d%02d",
@@ -73,8 +75,8 @@ char *demoAutoFormat(const char* name) {
 				outIndex += strlen( outBuf + outIndex );
 				break;
 			case 's':
-				Com_sprintf( outBuf + outIndex, outLeft, serverName );
-				outIndex += strlen( outBuf + outIndex );
+				Com_sprintf(outBuf + outIndex, outLeft, serverName);
+				outIndex += strlen(outBuf + outIndex);
 				break;
 			case 't':		//timestamp
 				while (demo.record.timeStamps[t] && t < MAX_TIMESTAMPS) {

--- a/codemp/client/cl_demos_auto.cpp
+++ b/codemp/client/cl_demos_auto.cpp
@@ -44,11 +44,31 @@ char *demoAutoFormat(const char* name) {
 			char ch = *format++;
 			haveTag = qfalse;
 			switch (ch) {
-			// let strftime handle its tokens, and ignore those with illegal characters
-			case 'a':   case 'A':   case 'b':   case 'B': /*case 'c':*/ case 'd':
-			case 'H':   case 'I':   case 'm':   case 'M':   case 'p':   case 'S':
-			case 'u':   case 'w': /*case 'x':   case 'X':*/ case 'y':   case 'Y':
-			case 'Z':
+			// a: Abbreviated weekday name (Thu)
+			// A: Full weekday name (Thursday)
+			// b: Abbreviated month name (Aug)
+			// B: Full month name (August)
+			// D: Day of the month, zero-padded (01-31)
+			// H: Hour in 24h format (00-23)
+			// I: Hour in 12h format (01-12)
+			// j: Day of the year (001-366)
+			// N: Month as a decimal number (01-12)
+			// M: Minute (00-59)
+			// P: AM or PM designation
+			// S: Second (00-61)
+			// U: Week number with the first Sunday as the first day of week one (00-53)
+			// w: Weekday as a decimal number with Sunday as 0 (0-6)
+			// y: Year, last two digits (00-99)
+			// Y: Year (2001)
+			// Z: Timezone abbreviation (CDT)
+			case 'a':   case 'A':   case 'b':   case 'B': /*case 'c':*/ case 'D':
+			case 'H':   case 'I':   case 'j':   case 'N':   case 'M':   case 'P':
+			case 'S':   case 'U':   case 'w': /*case 'x':   case 'X':*/ case 'y':
+			case 'Y':   case 'Z':
+				// change a few tokens
+				if (ch == 'D') ch = 'd';
+				else if (ch == 'N') ch = 'm';
+				else if (ch == 'P') ch = 'p';
 				// we can't just cast the struct because of undefined compiler behaviour
 				tt.tm_sec = ct.tm_sec; tt.tm_min = ct.tm_min; tt.tm_hour = ct.tm_hour;
 				tt.tm_mday = ct.tm_mday; tt.tm_mon = ct.tm_mon; tt.tm_year = ct.tm_year;
@@ -56,13 +76,13 @@ char *demoAutoFormat(const char* name) {
 				strftime(outBuf + outIndex, outLeft, va("%%%c", ch), &tt);
 				outIndex += strlen(outBuf + outIndex);
 				break;
-			case 'D':		//date
+			case 'd':		//date
 				Com_sprintf( outBuf + outIndex, outLeft, "%d-%02d-%02d-%02d%02d%02d",
 								1900+ct.tm_year, ct.tm_mon+1,ct.tm_mday,
 								ct.tm_hour, ct.tm_min, ct.tm_sec);
 				outIndex += strlen( outBuf + outIndex );
 				break;
-			case 'N':		//map
+			case 'm':		//map
 				Com_sprintf( outBuf + outIndex, outLeft, mapName);
 				outIndex += strlen( outBuf + outIndex );
 				break;
@@ -70,7 +90,7 @@ char *demoAutoFormat(const char* name) {
 				Com_sprintf( outBuf + outIndex, outLeft, name);
 				outIndex += strlen( outBuf + outIndex );
 				break;
-			case 'P':		//current player name
+			case 'p':		//current player name
 				Com_sprintf( outBuf + outIndex, outLeft, playerName);
 				outIndex += strlen( outBuf + outIndex );
 				break;

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -2897,7 +2897,7 @@ void CL_Init( void ) {
 
 	
 	cl_autoDemo = Cvar_Get ("cl_autoDemo", "1", CVAR_ARCHIVE );
-	cl_autoDemoFormat = Cvar_Get ("cl_autoDemoFormat", "%t_%N", CVAR_ARCHIVE );
+	cl_autoDemoFormat = Cvar_Get ("cl_autoDemoFormat", "%t_%m", CVAR_ARCHIVE );
 	Cmd_AddCommand ("saveDemo", demoAutoSave_f);
 	Cmd_AddCommand ("saveDemoLast", demoAutoSaveLast_f);
 

--- a/codemp/client/cl_main.cpp
+++ b/codemp/client/cl_main.cpp
@@ -2897,7 +2897,7 @@ void CL_Init( void ) {
 
 	
 	cl_autoDemo = Cvar_Get ("cl_autoDemo", "1", CVAR_ARCHIVE );
-	cl_autoDemoFormat = Cvar_Get ("cl_autoDemoFormat", "%t_%m", CVAR_ARCHIVE );
+	cl_autoDemoFormat = Cvar_Get ("cl_autoDemoFormat", "%t_%N", CVAR_ARCHIVE );
 	Cmd_AddCommand ("saveDemo", demoAutoSave_f);
 	Cmd_AddCommand ("saveDemoLast", demoAutoSaveLast_f);
 


### PR DESCRIPTION
strftime timestamps make it very easy to organize demos on a folder hierarchy (like year/month/day etc). Some tokens were commented because they contain illegal characters in OS file paths, and some old tokens were renamed since they were using reserved strftime tokens.

This is a modified merge, I didn't try to compile it but it should work fine as it did on cgame.